### PR TITLE
hotfix - screen off greater than on time bug

### DIFF
--- a/src/modules/player/components/SKPlayer/SKPlayer.tsx
+++ b/src/modules/player/components/SKPlayer/SKPlayer.tsx
@@ -161,9 +161,11 @@ export const SKPlayer = ({
   // isScreenOn flag should be true which means screen is scheduled
   // Note: if both screenOnTime and screenOffTime are empty it means screen will be played 24/7 on player
   if (
-    (!isScreenOn && screenId && screenOnTime && screenOffTime) ||
-    (!isScreenOn && screenId && screenOnTime && !screenOffTime) ||
-    (!isScreenOn && screenId && !screenOnTime && screenOffTime)
+    !isScreenOn &&
+    screenId &&
+    ((screenOnTime && screenOffTime) ||
+      (screenOnTime && !screenOffTime) ||
+      (!screenOnTime && screenOffTime))
   ) {
     return (
       <EmptyPlayer

--- a/src/modules/player/helpers/player.helper.ts
+++ b/src/modules/player/helpers/player.helper.ts
@@ -125,7 +125,11 @@ export const isScreenScheduleValid = (screenOnTime, screenOffTime) => {
   const format = "hh:mm:ss"; // Use 'HH' for 24-hour format
   const time = moment();
   const beforeTime = moment(screenOnTime, format);
-  const afterTime = moment(screenOffTime, format);
+  let afterTime = moment(screenOffTime, format);
+  // If screenOffTime is before screenOnTime, add a day to screenOff
+  if (afterTime.isBefore(beforeTime)) {
+    afterTime = afterTime.add(1, 'day');
+  }
   return time.isBetween(beforeTime, afterTime) || time.isSame(beforeTime);
 };
 


### PR DESCRIPTION
screen on time more than screen off time. like screen_on: 4:30 , screen_off: 4:00 then screen does not play **fixed**